### PR TITLE
feat: add responsive board and square components

### DIFF
--- a/src/game/Board.tsx
+++ b/src/game/Board.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import Square from './Square';
+
+type Player = 'X' | 'O';
+
+interface GameState {
+  squares: (Player | null)[];
+  turn: Player;
+  winner: Player | null;
+}
+
+const winningLines = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6],
+];
+
+const calculateWinner = (squares: (Player | null)[]): Player | null => {
+  for (const [a, b, c] of winningLines) {
+    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
+      return squares[a];
+    }
+  }
+  return null;
+};
+
+const Board: React.FC<{ player?: Player }> = ({ player = 'X' }) => {
+  const [game, setGame] = useState<GameState>({
+    squares: Array(9).fill(null),
+    turn: 'X',
+    winner: null,
+  });
+
+  const handleClick = (i: number) => {
+    if (game.squares[i] || game.winner || game.turn !== player) return;
+    const nextSquares = game.squares.slice();
+    nextSquares[i] = game.turn;
+    const winner = calculateWinner(nextSquares);
+    setGame({
+      squares: nextSquares,
+      turn: game.turn === 'X' ? 'O' : 'X',
+      winner,
+    });
+  };
+
+  const boardDisabled = game.turn !== player || !!game.winner;
+
+  return (
+    <div className={`grid grid-cols-3 gap-2 w-full max-w-xs ${boardDisabled ? 'pointer-events-none' : ''}`}>
+      {game.squares.map((value, idx) => (
+        <Square key={idx} value={value} index={idx} onClick={() => handleClick(idx)} />
+      ))}
+    </div>
+  );
+};
+
+export default Board;

--- a/src/game/Square.tsx
+++ b/src/game/Square.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface SquareProps {
+  value: string | null;
+  index: number;
+  onClick: () => void;
+}
+
+const Square: React.FC<SquareProps> = ({ value, index, onClick }) => {
+  const position = index + 1;
+  return (
+    <button
+      className="flex items-center justify-center text-xl font-bold border w-full aspect-square"
+      onClick={onClick}
+      aria-label={`square ${position} ${value ? value : 'empty'}`}
+    >
+      {value}
+    </button>
+  );
+};
+
+export default Square;


### PR DESCRIPTION
## Summary
- implement `Board` component with turn-based state and board disabling
- add `Square` component with position/state aria labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a25e3412c832e8083c41ccd518e44